### PR TITLE
Hid Unused Social Favicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,15 +321,15 @@
 			<ul>
 				<li><a href="https://www.facebook.com/hack.at.state/"><i class="fa fa-facebook"></i></a></li>
 				<li><a href="https://twitter.com/spartanhackers"><i class="fa fa-twitter"></i></a></li>
-				<li><a href="#"><i class="fa fa-linkedin"></i></a></li>
+				<!--<li><a href="#"><i class="fa fa-linkedin"></i></a></li>-->
 				<li><a href="https://www.youtube.com/channel/UCEsVXKr2P-el9TugNDmwj_g"><i class="fa fa-youtube"></i></a></li>
-				<li><a href="#"><i class="fa fa-meetup"></i></a></li>
+				<!--<li><a href="#"><i class="fa fa-meetup"></i></a></li>-->
 				<li><a href="https://csemsu.slack.com/signup"><i class="fa fa-slack"></i></a></li>
 				<li><a href="https://trello.com/spartanhackers"><i class="fa fa-trello"></i></a></li>
 				<li><a href="https://github.com/SpartanHackers"><i class="fa fa-github"></i></a></li>
-				<li><a href="https://github.com/SpartanHackers/spartancs.github.io"><i class="fa fa-html5"></i></a></li>
-				<li><a href="#"><i class="fa fa-apple"></i></a></li>
-				<li><a href="#"><i class="fa fa-android"></i></a></li>
+				<!--<li><a href="https://github.com/SpartanHackers/spartancs.github.io"><i class="fa fa-html5"></i></a></li>-->
+				<!--<li><a href="#"><i class="fa fa-apple"></i></a></li>-->
+				<!--<li><a href="#"><i class="fa fa-android"></i></a></li>-->
 			</ul> 
 		</nav>
 


### PR DESCRIPTION
This should resolve the following - https://github.com/SpartanHackers/spartanhackers.github.io/issues/1 - issue. Hope this helps for you. 

I decided to hide the unused code rather than removing it as other code that is unused is hidden as well. We may wish to change this in the future to increase loading time and better manage resources for both the client and the server. Due to the nature of git, we will have a reference to the previous code and we can restore it if ever necessary. 